### PR TITLE
Use tqdm for progress bar for evaluate.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Or like this when trained on Librispeech (see "Decoding and evaluating a trained
 1. Make sure you have [neon](https://github.com/NervanaSystems/neon) installed.  
     a. This repo also uses the [aeon](https://github.com/NervanaSystems/aeon) dataloader. If you chose not to install it with neon, you must install it manually.
 
-2. Within a neon virtualenv, run ```pip install python-levenshtein```.
+2. Clone this repository: ```git clone https://github.com/NervanaSystems/deepspeech.git && cd deepspeech```
 
-3. Clone this repository: ```git clone https://github.com/NervanaSystems/deepspeech.git && cd deepspeech```
+3. Within a neon virtualenv, run ```pip install -r requirements.txt```.
 
 4. Run ```make``` to build warp-ctc.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 python-levenshtein==0.12.0
+tqdm==4.8.4

--- a/speech/evaluate.py
+++ b/speech/evaluate.py
@@ -44,6 +44,8 @@ parser.add_argument('--use_wer', action="store_true",
                     help='compute wer instead of cer.')
 parser.add_argument('--inference_file', default=None,
                     help='saves results in inference_file.')
+parser.add_argument('--print_examples', action="store_true",
+                    help='print an example transcript for each batch')
 args = parser.parse_args()
 
 if args.model_file is None:
@@ -100,7 +102,7 @@ model = Model(args.model_file)
 
 # Process data and compute stats
 wer, sample_size, results = get_wer(model, be, eval_set, argmax_decoder, nout,
-                                    use_wer=args.use_wer)
+                                    use_wer=args.use_wer, print_examples=args.print_examples)
 
 print("\n" + "-" * 80)
 if args.use_wer:


### PR DESCRIPTION
Closes #41 and gives a nicer progress bar overall. You can now also specify the `--print_examples` argument to `evaluate.py` to print one example transcript per batch.